### PR TITLE
add nir256

### DIFF
--- a/seabreeze/pyseabreeze/interfaces/__init__.py
+++ b/seabreeze/pyseabreeze/interfaces/__init__.py
@@ -1,3 +1,8 @@
+'''
+addition attempt of the nir256
+
+'''
+
 from .common import SeaBreezeError
 from .spectrometer import (
                             SpectrometerFeatureUSB2000,
@@ -19,6 +24,7 @@ from .spectrometer import (
                             SpectrometerFeatureSTS,
                             SpectrometerFeatureQEPRO,
                             SpectrometerFeatureVENTANA,
+                            SpectrometerFeatureNIR256,
                           )
 
 from .wavelength import WavelengthCoefficientsEEPromFeature
@@ -64,6 +70,20 @@ class HR2000(SpectrometerFeatureHR2000,
     _INTEGRATION_TIME_MAX = 655350000
     _INTEGRATION_TIME_BASE = 1000
     _MAX_PIXEL_VALUE = 4095
+class NIR256(SpectrometerFeatureNIR256,
+             WavelengthCoefficientsEEPromFeature,
+             NonlinearityCoefficientsEEPromFeature,
+             EEPromFeature,
+             NoShutterFeature,
+             NoTecFeature,
+             NotImplementedWrapper):
+    _ENDPOINT_MAP = EndPoints['NIR256']
+    _PIXELS = 256  # FIXME
+    _RAW_SPECTRUM_LEN = (256 * 2) + 1
+    _INTEGRATION_TIME_MIN = 1000
+    _INTEGRATION_TIME_MAX = 655350000
+    _INTEGRATION_TIME_BASE = 1000
+    _MAX_PIXEL_VALUE = 16383
 
 class HR4000(SpectrometerFeatureHR4000,
              WavelengthCoefficientsEEPromFeature,
@@ -339,5 +359,6 @@ USBInterfaces = {
     0x4000: STS,
     0x4004: QEPRO,
     0x5000: VENTANA,
+    0x1010: NIR256,
 }
 

--- a/seabreeze/pyseabreeze/interfaces/defines.py
+++ b/seabreeze/pyseabreeze/interfaces/defines.py
@@ -1,8 +1,14 @@
+'''
+addition attempt of the nir256
+
+'''
+
 """
 File:           defines.py
 Author:         Andreas Poehlmann
 
 Some definitions
+
 """
 
 VendorId = 0x2457
@@ -26,6 +32,7 @@ ModelNames = {
     0x4000: 'STS',
     0x4004: 'QEPRO',
     0x5000: 'VENTANA',
+    0x1010: 'NIR256',
 }
 ProductIds = list(ModelNames.keys())
 SpectrometerClasses = list(ModelNames.values())
@@ -50,6 +57,7 @@ DarkPixels = {
     'STS'	  : [],
     'QEPRO'	  : list(range(0, 4)) + list(range(1040, 1044)),
     'VENTANA'	  : [],
+    'NIR256'	  : [],####to be determined
 }
 
 
@@ -87,6 +95,7 @@ EndPoints= {
      'STS'	   : _EMDUAL,
      'QEPRO'	   : _EMDUAL,
      'VENTANA'	   : _EMVENT,
+     'NIR256'	   : _EML2K,
 }
 
 
@@ -177,6 +186,10 @@ TriggerModes = {
        'FREE_RUNNING' : 0,
        'SOFTWARE'     : 1,
        'EXT_HW'       : 3,
+        },
+    'NIR256'	   : { 
+       'FREE_RUNNING' : 0,
+       'SOFTWARE'     : 1,
         },
 }
 

--- a/seabreeze/pyseabreeze/interfaces/spectrometer.py
+++ b/seabreeze/pyseabreeze/interfaces/spectrometer.py
@@ -1,4 +1,7 @@
+'''
+addition attempt of the nir256
 
+'''
 from .common import SeaBreezeError, get_pyseabreeze_decorator
 from .communication import USBCommOOI, USBCommOBP
 from .defines import ModelNames, DarkPixels, TriggerModes
@@ -358,6 +361,8 @@ class SpectrometerFeatureUSB2000(SpectrometerFeatureOOI2K):
 
 
 class SpectrometerFeatureHR2000(SpectrometerFeatureOOI2K):
+    pass
+class SpectrometerFeatureNIR256(SpectrometerFeatureOOI2K):
     pass
 
 


### PR DESCRIPTION
In order to use the seabreeze library with the Ocean Optics NIR256 2.5, I tried to add this spectrometer in every files where I could see the other spectrometers mentionned.